### PR TITLE
Add health checks for MySQL services in stack.yml

### DIFF
--- a/roles/compose/files/stack.yml
+++ b/roles/compose/files/stack.yml
@@ -184,6 +184,11 @@ services:
       - mysql_mail_root_password
     networks:
       - mail_internal
+    healthcheck:
+      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_mail_root_password) || exit 1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     deploy:
       restart_policy:
         condition: on-failure
@@ -561,6 +566,11 @@ services:
       - mysql_wordpress_noerpel_root_password
     networks:
       - wordpress_noerpel_internal
+    healthcheck:
+      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_mail_root_password) || exit 1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
### Description

This pull request introduces health check configurations for MySQL services within `stack.yml`. The changes are aimed at improving the monitoring and reliability of MySQL services by including periodic `mysqladmin ping` commands. These checks are configured with appropriate intervals, timeouts, and retry settings to ensure the availability and responsiveness of MySQL.
