### PR TITLE
Add healthcheck configurations to stack.yml

### DIFF
--- a/roles/compose/files/stack.yml
+++ b/roles/compose/files/stack.yml
@@ -427,6 +427,8 @@ services:
     networks:
       - cloud_nesono_internal
       - http_external
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost/index.php || exit 1" ]
     depends_on:
       - mariadb_cloud_nesono
       - redis_cloud_nesono
@@ -503,6 +505,8 @@ services:
     networks:
       - cloud_noerpel_internal
       - http_external
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost/index.php || exit 1" ]
     depends_on:
       - mariadb_cloud_noerpel
       - redis_cloud_noerpel
@@ -518,6 +522,8 @@ services:
       LETSENCRYPT_HOST: the.issing.link
     networks:
       - http_external
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost/ || exit 1" ]
     deploy:
       restart_policy:
         condition: on-failure
@@ -532,6 +538,8 @@ services:
       LETSENCRYPT_HOST: katja.issing.link
     networks:
       - http_external
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost/ || exit 1" ]
     deploy:
       restart_policy:
         condition: on-failure
@@ -546,6 +554,8 @@ services:
       LETSENCRYPT_HOST: www.nesono.com
     networks:
       - http_external
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost/ || exit 1" ]
     deploy:
       restart_policy:
         condition: on-failure
@@ -568,9 +578,6 @@ services:
       - wordpress_noerpel_internal
     healthcheck:
       test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_mail_root_password) || exit 1" ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
     deploy:
       restart_policy:
         condition: on-failure
@@ -591,6 +598,8 @@ services:
     networks:
       - http_external
       - wordpress_noerpel_internal
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost/ || exit 1" ]
     deploy:
       restart_policy:
         condition: on-failure

--- a/roles/compose/files/stack.yml
+++ b/roles/compose/files/stack.yml
@@ -90,6 +90,9 @@ services:
     networks:
       - mail_external
       - mail_internal
+    healthcheck:
+      test: [ "CMD-SHELL", "echo -ne 'A001 CAPABILITY\r\nA002 LOGOUT\r\n' | openssl s_client -connect localhost:993 -quiet | grep 'CAPABILITY'
+    " ]
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
### Summary
This pull request introduces healthcheck configurations for services defined in `stack.yml`. These changes utilize `curl` to verify service availability across multiple containers, ensuring automatic monitoring and improved resilience. Additionally, redundant healthcheck parameters were removed for consistency.

### Changes
- Added healthcheck settings using HTTP endpoints for service monitoring.
- Removed redundant healthcheck configurations to streamline definitions.

### Benefits
- Improved system resilience and automatic service monitoring.
- Cleaner and more consistent configuration