### PR TITLE
Add commented configuration for postfix_exporter example

### DIFF
--- a/roles/compose/files/stack.yml
+++ b/roles/compose/files/stack.yml
@@ -690,6 +690,23 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
 
+#  postfix_exporter:
+#    image: nesono/postfix_exporter:2025-03-23
+#    command:
+#      - '--web.listen-address=9154'
+#      - '--postfix.showq_path=/var/spool/mail/public/showq'
+#      - '--docker.enable'
+#      - '--docker.container.id=postfix'
+#    networks:
+#      - monitoring
+#    deploy:
+#      restart_policy:
+#        condition: on-failure
+#    volumes:
+#      - mail_spool:/var/spool/mail
+#      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+
 #  blackbox_exporter:
 #    image: prom/blackbox-exporter:latest
 #    networks:

--- a/roles/compose/files/stack.yml
+++ b/roles/compose/files/stack.yml
@@ -690,6 +690,7 @@ services:
       - /sys:/host/sys:ro
       - /:/rootfs:ro
 
+## TODO: uncomment this after migration to docker compose - it fails due to docker name resolution of "postfix"
 #  postfix_exporter:
 #    image: nesono/postfix_exporter:2025-03-23
 #    command:


### PR DESCRIPTION
### Description

This PR introduces a commented-out configuration example for `postfix_exporter` in the `stack.yml` file. The example serves as a reference for potential future configurations, detailing network and volume bindings to ensure clarity and ease of implementation