### PR TITLE
Add Minecraft server to Docker Compose configuration

### DIFF
--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -29,6 +29,25 @@ services:
       export MAIL_USER=$$(cat $$BORG_MAIL_USER_FILE) && export
       MAIL_PASSWORD=$$(cat $$BORG_MAIL_PASSWORD_FILE) && exec /entry.sh"
     restart: on-failure
+  minecraft:
+    image: itzg/minecraft-server
+    ports:
+      - "25565:25565"
+    volumes:
+      - minecraft_data:/data
+    environment:
+      EULA: true
+      TYPE: NEOFORGE
+      VERSION: "1.21.1"
+      NEOFORGE_VERSION: "21.1.172"
+      MOTD: "Moin Diggas!"
+      WHITELIST: |
+        Leo18771
+        DarthAdrian23
+        PlageGeist0903
+        PutaRe747474
+      OPS: |
+        Leo18771
 
 volumes:
   borgmatic_config:
@@ -61,6 +80,12 @@ volumes:
       o: bind
       type: none
       device: /svc/volumes/borgmatic/cache
+  minecraft_data:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: /svc/volumes/minecraft_data
 
 secrets:
   borgmatic_passphrase:

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -40,14 +40,20 @@ services:
       TYPE: NEOFORGE
       VERSION: "1.21.1"
       NEOFORGE_VERSION: "21.1.172"
+      SERVER_NAME: "Tha Dudes"
       MOTD: "Moin Diggas!"
+      MEMORY: 16G
+      VIEW_DISTANCE: 32
       WHITELIST: |
         Leo18771
         DarthAdrian23
         PlageGeist0903
         PutaRe747474
+        Swulfen12
       OPS: |
         Leo18771
+    restart: unless-stopped
+
 
 volumes:
   borgmatic_config:

--- a/roles/compose/tasks/main.yaml
+++ b/roles/compose/tasks/main.yaml
@@ -38,6 +38,7 @@
     - the_issing_link_data
     - katja_issing_link_data
     - prometheus_etc
+    - minecraft_data
   tags: [provision]
 
 - name: Create volume for postgres services (uid 70, gid 70)

--- a/roles/compose/tasks/main.yaml
+++ b/roles/compose/tasks/main.yaml
@@ -38,7 +38,6 @@
     - the_issing_link_data
     - katja_issing_link_data
     - prometheus_etc
-    - minecraft_data
   tags: [provision]
 
 - name: Create volume for postgres services (uid 70, gid 70)
@@ -152,6 +151,17 @@
     mode: '0755'
   loop:
     - prometheus_data
+  tags: [ provision ]
+
+- name: Create volume for Minecraft data (uid 1000, gid 1000, mod 0750)
+  ansible.builtin.file:
+    path: "/svc/volumes/{{ item }}"
+    state: directory
+    owner: 1000
+    group: 1000
+    mode: '0750'
+  loop:
+    - minecraft_data
   tags: [ provision ]
 
 - name: Copy nginx template


### PR DESCRIPTION
```markdown
### Description
This pull request adds a Minecraft server to the existing Docker Compose configuration. It uses the `itzg/minecraft-server` image and includes service definitions, environment variable configurations, and a data volume. Tasks for provisioning have also been updated accordingly.

### Changes
- Added a Minecraft server service to the Docker Compose setup.
- Configured environment variables for the Minecraft server.
- Set up a data volume for persistent storage.
- Updated provisioning tasks to account for the new service.

```