### PR TITLE
Add spawn protection and update server operators list

### DIFF
--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -43,6 +43,7 @@ services:
       SERVER_NAME: "Tha Dudes"
       MOTD: "Moin Diggas!"
       MEMORY: 16G
+      SPAWN_PROTECTION: 0
       VIEW_DISTANCE: 32
       WHITELIST: |
         Leo18771
@@ -52,6 +53,7 @@ services:
         Swulfen12
       OPS: |
         Leo18771
+        PlageGeist0903
     restart: unless-stopped
 
 

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       VERSION: "1.21.1"
       NEOFORGE_VERSION: "21.1.172"
       SERVER_NAME: "Tha Dudes"
-      MOTD: "Moin Diggas!"
+      MOTD: "Hello hello hello!"
       MEMORY: 16G
       SPAWN_PROTECTION: 0
       VIEW_DISTANCE: 32

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -56,7 +56,6 @@ services:
         PlageGeist0903
     restart: unless-stopped
 
-
 volumes:
   borgmatic_config:
     driver: local


### PR DESCRIPTION
Introduced a `SPAWN_PROTECTION` environment variable with a value of 0 to define spawn protection in the Minecraft server configuration. Also, added `PlageGeist0903` to the operators list