### PR TITLE
chore(nextcloud): upgrade Nextcloud services to 31

### DIFF
--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -420,7 +420,7 @@ services:
     restart: unless-stopped
 
   cloud_nesono_com:
-    image: nextcloud:30
+    image: nextcloud:31
     volumes:
       - cloud_nesono_nextcloud:/var/www/html
       - cloud_nesono_apps:/var/www/html/custom_apps
@@ -507,7 +507,7 @@ services:
     restart: unless-stopped
 
   cloud_noerpel_com:
-    image: nextcloud:30
+    image: nextcloud:31
     volumes:
       - cloud_noerpel_nextcloud:/var/www/html
       - cloud_noerpel_apps:/var/www/html/custom_apps


### PR DESCRIPTION
This PR upgrades both Nextcloud services from 30 to 31 in roles/compose/files/docker-compose.yaml.\n\nServices updated:\n- cloud_nesono_com: nextcloud:31\n- cloud_noerpel_com: nextcloud:31\n\nPre-commit checks (YAML, ansible-lint, prettier) passed locally.\n\nPlease review and merge.