### PR TITLE
Upgrade MySQL from 5.7 to 8.0 (step 1 of LTS migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ borg init --encryption=repokey-blake2 ssh://uXXXXXX@uXXXXXX.your-backup.de:23/ho
 Start a borgmatic shell with the following commands:
 
 ```bash
-docker exec -ti $(docker ps -q -f name=borg-backup) bash
+docker compose -f /svc/volumes/docker-compose/docker-compose.yaml exec -ti borg-backup bash
 export BORG_PASSPHRASE=$(cat $BORG_PASSPHRASE_FILE)
 ```
 

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -98,7 +98,7 @@ services:
 
   # MySQL database for mail
   mysql_mail:
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - mysql_mail_data:/var/lib/mysql
       - mysql_mail_init_db:/docker-entrypoint-initdb.d
@@ -624,7 +624,7 @@ services:
 
   # WordPress services
   mysql_wordpress_noerpel:
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - mysql_wordpress_noerpel_data:/var/lib/mysql
     environment:

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -119,10 +119,10 @@ services:
           "CMD-SHELL",
           "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_mail_root_password) || exit 1",
         ]
-    #   interval: 30s
-    #   timeout: 10s
-    #   retries: 3
-    # restart: unless-stopped
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
 
   # Dovecot IMAP server
   dovecot:
@@ -186,7 +186,7 @@ services:
       - mysql_mail
       - dovecot # SASL authentication
       - postfix_milters
-    image: nesono/postfix_for_postfixadmin:2026-03-22
+    image: nesono/postfix_for_postfixadmin:2026-02-16
     container_name: postfix
     environment:
       MYHOSTNAME: "smtp.nesono.com"
@@ -638,13 +638,13 @@ services:
       - mysql_wordpress_noerpel_root_password
     networks:
       - wordpress_noerpel_internal
-    # healthcheck:
-    #   test:
-    #     [
-    #       "CMD-SHELL",
-    #       "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_wordpress_noerpel_root_password) || exit 1",
-    #     ]
-    # restart: unless-stopped
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_wordpress_noerpel_root_password) || exit 1",
+        ]
+    restart: unless-stopped
 
   wordpress_noerpel:
     image: wordpress:6.8

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -186,7 +186,7 @@ services:
       - mysql_mail
       - dovecot # SASL authentication
       - postfix_milters
-    image: nesono/postfix_for_postfixadmin:2026-02-16
+    image: nesono/postfix_for_postfixadmin:2026-02-16.1
     container_name: postfix
     environment:
       MYHOSTNAME: "smtp.nesono.com"

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -119,10 +119,10 @@ services:
           "CMD-SHELL",
           "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_mail_root_password) || exit 1",
         ]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    restart: unless-stopped
+    #   interval: 30s
+    #   timeout: 10s
+    #   retries: 3
+    # restart: unless-stopped
 
   # Dovecot IMAP server
   dovecot:
@@ -638,13 +638,13 @@ services:
       - mysql_wordpress_noerpel_root_password
     networks:
       - wordpress_noerpel_internal
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_wordpress_noerpel_root_password) || exit 1",
-        ]
-    restart: unless-stopped
+    # healthcheck:
+    #   test:
+    #     [
+    #       "CMD-SHELL",
+    #       "mysqladmin ping -h localhost -u root -p$$(cat /run/secrets/mysql_wordpress_noerpel_root_password) || exit 1",
+    #     ]
+    # restart: unless-stopped
 
   wordpress_noerpel:
     image: wordpress:6.8


### PR DESCRIPTION
## Summary
- Upgrades `mysql_mail` and `mysql_wordpress_noerpel` from MySQL 5.7 to 8.0
- This is step 1 of a safe migration path to MySQL 8.4 LTS (5.7 → 8.0 → 8.4)
- MySQL only supports upgrading one major version at a time; the Renovate PR #66 jumping directly to 9.6 would break data compatibility

## Pre-deployment checklist
- [x] Back up `mysql_mail_data` volume
- [x] Back up `mysql_wordpress_noerpel_data` volume

## Post-deployment verification
- [x] Both MySQL containers start without errors
- [x] Dovecot/Postfix/Postfixadmin connect to `mysql_mail` successfully
- [x] WordPress connects to `mysql_wordpress_noerpel` successfully
- [x] Mail login/sending works end-to-end

## Next steps
- **Step 2:** Upgrade MySQL 8.0 → 8.4 LTS (separate PR)
- **Step 3:** Pin Renovate to only allow patch updates within 8.4.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)