### PR TITLE
Pin Renovate to MySQL 8.4 LTS patch updates only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["mysql"],
+      "allowedVersions": "8.4.*"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Restricts Renovate MySQL proposals to `8.4.*` patch updates only
- Prevents accidental upgrades to Innovation releases (9.x) which are short-lived and not production-suitable
- This was the root cause of the original #66 PR that proposed jumping from 5.7 to 9.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)