### PR TITLE
Replace postfix + postfix_milters with unified container

### DIFF
--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -165,7 +165,7 @@ services:
     depends_on:
       - mysql_mail
       - dovecot # SASL authentication
-    image: nesono/postfix_for_postfixadmin:2026-04-06
+    image: nesono/postfix_for_postfixadmin:2026-04-06.1
     container_name: postfix
     environment:
       MYHOSTNAME: "smtp.nesono.com"

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -165,7 +165,7 @@ services:
     depends_on:
       - mysql_mail
       - dovecot # SASL authentication
-    image: nesono/postfix_for_postfixadmin:2026-04-06.1
+    image: nesono/postfix_for_postfixadmin:2026-04-11.2
     container_name: postfix
     environment:
       MYHOSTNAME: "smtp.nesono.com"
@@ -184,7 +184,7 @@ services:
       AUTHORIZED_SMTPD_XCLIENT_HOSTS: "172.20.0.1"
       SPAMHAUS_DISABLE: "1"
       # Milter env vars (previously on postfix_milters container)
-      POSTGREY_SOCKET_PATH: "private/postgrey"
+      # POSTGREY_SOCKET_PATH: "private/postgrey"
       SPAMASS_SOCKET_PATH: "private/spamass"
       DKIM_SOCKET_PATH: "private/dkim"
       DKIM_DOMAINS: "nesono.com,issing.link,noerpel.net,frankfriedbert.de,byorkesterbaritone.com"

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -165,7 +165,7 @@ services:
     depends_on:
       - mysql_mail
       - dovecot # SASL authentication
-    image: nesono/postfix_for_postfixadmin:2026-04-04.1
+    image: nesono/postfix_for_postfixadmin:2026-04-06
     container_name: postfix
     environment:
       MYHOSTNAME: "smtp.nesono.com"

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -160,31 +160,13 @@ services:
         ]
     restart: unless-stopped
 
-  # Postfix milters (DKIM, DMARC)
-  postfix_milters:
-    image: nesono/postfix-milters:2023-01-22.1
-    environment:
-      SPAMASS_SOCKET_PATH: "private/spamass"
-      DKIM_SOCKET_PATH: "private/dkim"
-      DKIM_DOMAINS: "nesono.com,issing.link,noerpel.net,frankfriedbert.de,byorkesterbaritone.com"
-      DKIM_SELECTOR: "2023-01-04"
-      DKIM_KEY_PATH: "/run/secrets/opendkim_key"
-      DMARC_SOCKET_PATH: "private/dmarc"
-      MAIL_HOSTNAME: "smtp.nesono.com"
-    volumes:
-      - mail:/var/mail
-      - mail_spool:/var/spool/postfix
-      - spamass_vhome:/vhome/users
-    secrets:
-      - opendkim_key
-    networks:
-      - mail_internal
-    restart: unless-stopped
-
-  # Staging: unified postfix + milters (for validation before cutover)
-  postfix_staging:
+  # Postfix SMTP server (unified with milters since 2026-04-04)
+  postfix:
+    depends_on:
+      - mysql_mail
+      - dovecot # SASL authentication
     image: nesono/postfix_for_postfixadmin:2026-04-04.1
-    container_name: postfix_staging
+    container_name: postfix
     environment:
       MYHOSTNAME: "smtp.nesono.com"
       MYNETWORKS: "5.9.123.102"
@@ -198,9 +180,10 @@ services:
       DOVECOT_LMTP_PATH: "private/dovecot-lmtp"
       SPF_ENABLE: "1"
       SMTPS_ENABLE: "1"
+      CERT_NAME: "mail.nesono.com"
       AUTHORIZED_SMTPD_XCLIENT_HOSTS: "172.20.0.1"
       SPAMHAUS_DISABLE: "1"
-      # Milter env vars (merged from postfix_milters)
+      # Milter env vars (previously on postfix_milters container)
       POSTGREY_SOCKET_PATH: "private/postgrey"
       SPAMASS_SOCKET_PATH: "private/spamass"
       DKIM_SOCKET_PATH: "private/dkim"
@@ -214,53 +197,13 @@ services:
       - mysql_mail_user
       - opendkim_key
     ports:
-      - "127.0.0.1:2525:25" # localhost only, for testing
-    volumes:
-      - mail:/var/mail
-      - mail_spool_staging:/var/spool/postfix
-      - spamass_vhome:/vhome/users
-      - /svc/volumes/acme/certs/mail.nesono.com:/etc/postfix/certs:ro
-    networks:
-      - mail_external
-      - mail_internal
-    restart: "no"
-
-  # Postfix SMTP server
-  postfix:
-    depends_on:
-      - mysql_mail
-      - dovecot # SASL authentication
-      - postfix_milters
-    image: nesono/postfix_for_postfixadmin:2026-02-16.1
-    container_name: postfix
-    environment:
-      MYHOSTNAME: "smtp.nesono.com"
-      MYNETWORKS: "5.9.123.102"
-      SQL_USER_FILE: /run/secrets/mysql_mail_user
-      SQL_PASSWORD_FILE: /run/secrets/mysql_mail_password
-      SQL_HOST: mysql_mail
-      SQL_DB_NAME: mailserver
-      TLS_CERT: /etc/postfix/certs/fullchain.pem
-      TLS_KEY: /etc/postfix/certs/key.pem
-      DOVECOT_SASL_SOCKET_PATH: "private/auth"
-      DOVECOT_LMTP_PATH: "private/dovecot-lmtp"
-      DKIM_SOCKET_PATH: "private/dkim"
-      SPF_ENABLE: "1"
-      DMARC_SOCKET_PATH: "private/dmarc"
-      SMTPS_ENABLE: "1"
-      CERT_NAME: "mail.nesono.com"
-      AUTHORIZED_SMTPD_XCLIENT_HOSTS: "172.20.0.1"
-      SPAMHAUS_DISABLE: "1"
-    secrets:
-      - mysql_mail_password
-      - mysql_mail_user
-    ports:
       - "0.0.0.0:25:25" # SMTP (bind to all interfaces)
       - "0.0.0.0:465:465" # SMTPS (bind to all interfaces)
       - "0.0.0.0:587:587" # SUBMISSION (bind to all interfaces)
     volumes:
       - mail:/var/mail
       - mail_spool:/var/spool/postfix
+      - spamass_vhome:/vhome/users
       - /svc/volumes/acme/certs/mail.nesono.com:/etc/postfix/certs:ro
       - /dev/log:/dev/log
     networks:
@@ -893,12 +836,6 @@ volumes:
       o: bind
       type: none
       device: /svc/volumes/mail_spool
-  mail_spool_staging:
-    driver: local
-    driver_opts:
-      o: bind
-      type: none
-      device: /svc/volumes/mail_spool_staging
   mysql_mail_data:
     driver: local
     driver_opts:

--- a/roles/compose/tasks/main.yaml
+++ b/roles/compose/tasks/main.yaml
@@ -96,7 +96,6 @@
     mode: "0755"
   loop:
     - mail_spool
-    - mail_spool_staging
   tags: [provision]
 
 - name: Create volume for borgmatic keys (mode 0600)


### PR DESCRIPTION
## Summary

- Migrate from two-container setup (`postfix` 2026-02-16.1 + `postfix-milters` 2023-01-22.1) to single unified container (`postfix_for_postfixadmin` 2026-04-04.1)
- Remove `postfix_milters` and `postfix_staging` services
- Add milter env vars, `opendkim_key` secret, and `spamass_vhome` volume to `postfix` service
- Net result: -73 lines, +9 lines

## Behavior changes

- `POSTGREY_SOCKET_PATH` and `SPAMASS_SOCKET_PATH` are now set on the postfix container, activating postgrey greylisting and spamassassin policy checks in `smtpd_recipient_restrictions` (these milters were running before but not wired into postfix)

## Deployment

```bash
ansible-playbook -i production/hosts green_nesono.yml --tags hot_compose
```

The `--remove-orphans` in the compose task will automatically stop the old `postfix_milters` and `postfix_staging` containers.

## Validated on staging

All checks passed on `postfix_staging` container on production server:
- 9/9 supervisor services RUNNING
- PostSRSd responding on ports 10001/10002
- Socket permissions: `postfix:opendkim 775`
- DKIM KeyTable/SigningTable generated for all 5 domains
- DMARC config patched correctly
- SMTP responding with STARTTLS
- Entrypoint idempotent on restart

## Test plan

- [ ] Deploy via Ansible
- [ ] Verify all 9 services RUNNING: `docker exec postfix supervisorctl status`
- [ ] Verify SMTP on port 25: `echo QUIT | nc localhost 25`
- [ ] Send test email, verify DKIM signature in headers
- [ ] Monitor Grafana for delivery metrics
- [ ] Verify fail2ban still detects postfix auth failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)