### PR TITLE
Set innodb_default_row_format=dynamic for Nextcloud MariaDB

### DIFF
--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -377,6 +377,7 @@ services:
     volumes:
       - mariadb_cloud_nesono_data:/var/lib/mysql
       - mariadb_cloud_nesono_init_db:/docker-entrypoint-initdb.d
+      - ./mariadb_nextcloud.cnf:/etc/mysql/conf.d/nextcloud.cnf:ro
     environment:
       MARIADB_ROOT_PASSWORD_FILE: /run/secrets/mariadb_cloud_nesono_root_password
       MARIADB_USER_FILE: /run/secrets/mariadb_cloud_nesono_user
@@ -464,6 +465,7 @@ services:
     volumes:
       - mariadb_cloud_noerpel_data:/var/lib/mysql
       - mariadb_cloud_noerpel_init_db:/docker-entrypoint-initdb.d
+      - ./mariadb_nextcloud.cnf:/etc/mysql/conf.d/nextcloud.cnf:ro
     environment:
       MARIADB_ROOT_PASSWORD_FILE: /run/secrets/mariadb_cloud_noerpel_root_password
       MARIADB_USER_FILE: /run/secrets/mariadb_cloud_noerpel_user

--- a/roles/compose/files/mariadb_nextcloud.cnf
+++ b/roles/compose/files/mariadb_nextcloud.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+innodb_default_row_format = dynamic

--- a/roles/compose/tasks/main.yaml
+++ b/roles/compose/tasks/main.yaml
@@ -414,6 +414,15 @@
     mode: "0644"
   tags: [hot_compose]
 
+- name: Copy MariaDB Nextcloud config
+  ansible.builtin.copy:
+    src: mariadb_nextcloud.cnf
+    dest: /svc/volumes/docker-compose/mariadb_nextcloud.cnf
+    owner: 0
+    group: 0
+    mode: "0644"
+  tags: [hot_compose]
+
 - name: Deploy Docker Compose services
   ansible.builtin.command: docker compose up --wait --remove-orphans
   args:


### PR DESCRIPTION
## Summary
- Adds `mariadb_nextcloud.cnf` with `innodb_default_row_format = dynamic`
- Mounts it into both `mariadb_cloud_nesono` and `mariadb_cloud_noerpel`
- Ansible task copies the config file to the server

Fixes the Nextcloud admin warning about incorrect ROW_FORMAT on tables. Existing tables were already converted manually via SQL; this prevents recurrence for new tables.

## Test plan
- [x] Deploy via Ansible
- [x] Verify MariaDB picks up the config: `SHOW VARIABLES LIKE 'innodb_default_row_format'`
- [x] Nextcloud admin panel no longer shows ROW_FORMAT warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)