### PR TITLE
Pin postgres to major version 15 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["mysql"],
       "allowedVersions": "8.4.*"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "15.*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule to restrict postgres Docker image updates to `15.*`
- Prevents automatic major version upgrade PRs, which require manual data migration and downtime
- Follows the same pattern already used for MySQL (`8.4.*`)

## Test plan
- [ ] Verify Renovate no longer proposes postgres major version bumps
- [ ] Verify postgres patch updates (e.g. 15.13 → 15.14) are still proposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)