### PR TITLE
Disable Alloy usage reporting

### DIFF
--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -720,7 +720,7 @@ services:
 
   alloy:
     image: grafana/alloy:latest
-    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/alloy.river
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data --disable-reporting /etc/alloy/alloy.river
     environment:
       TZ: UTC
     volumes:


### PR DESCRIPTION
## Summary
- Adds `--disable-reporting` flag to Alloy's command
- Alloy is on the internal `monitoring` network with no external DNS, causing repeated failed attempts to reach `stats.grafana.org`
- This eliminates the noisy retry logs filling up the container output

Closes #80

## Test plan
- [ ] Deploy and verify Alloy starts without errors
- [ ] Confirm no more `failed to send usage report` messages in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)