### PR TITLE
Pin Nextcloud MariaDB to 12.3 and hold Renovate there

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,11 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["postgres"],
       "allowedVersions": "15.*"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["mariadb"],
+      "allowedVersions": "12.3.*"
     }
   ]
 }

--- a/roles/compose/files/docker-compose.yaml
+++ b/roles/compose/files/docker-compose.yaml
@@ -373,7 +373,7 @@ services:
 
   # Cloud services - Nextcloud nesono
   mariadb_cloud_nesono:
-    image: mariadb:12
+    image: mariadb:12.3
     volumes:
       - mariadb_cloud_nesono_data:/var/lib/mysql
       - mariadb_cloud_nesono_init_db:/docker-entrypoint-initdb.d
@@ -461,7 +461,7 @@ services:
 
   # Cloud noerpel services
   mariadb_cloud_noerpel:
-    image: mariadb:12
+    image: mariadb:12.3
     volumes:
       - mariadb_cloud_noerpel_data:/var/lib/mysql
       - mariadb_cloud_noerpel_init_db:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## Problem

The Nextcloud MariaDB containers log:

> MariaDB version "12.3.2-MariaDB-ubu2404" detected. MariaDB >=10.6 and <=11.8 is suggested for best performance

The `mariadb:12` floating tag rolls forward to whatever the latest 12.x is (currently 12.3.2), and with no Renovate rule for `mariadb`, Renovate would also open PRs for major bumps (13.x). We want to stay on **12.3** for now — without downgrading.

## Change

- **`docker-compose.yaml`** — pin both Nextcloud MariaDB services from `mariadb:12` → `mariadb:12.3`, so Docker stays on the 12.3.x line instead of drifting to 12.4+.
- **`renovate.json`** — add a rule (`allowedVersions: "12.3.*"`) matching the existing `mysql`/`postgres` pins, so Renovate only proposes 12.3 **patch** updates — no minor or major bumps.

## Notes

- This does **not** downgrade the database; it holds the current 12.3 line.
- 12.3.x patch updates are still allowed (security fixes); minor (12.4) and major (13) are blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)